### PR TITLE
Changed the YouTubeServices.GetSize method return type to nullable long.

### DIFF
--- a/Spotisharp.Client/Services/YoutubeService.cs
+++ b/Spotisharp.Client/Services/YoutubeService.cs
@@ -59,7 +59,7 @@ public static class YoutubeService
 
     public static async Task<Stream> GetStreamAsync(string url, IProgress<Tuple<long, long>>? progress = null)
     {
-        long fileSize = await GetSize(url);
+        long fileSize = await GetSize(url) ?? 0;
         long totalBytesCopied = 0;
         long chunkSize = 65535; // 64KB
         Stream output = new MemoryStream();
@@ -102,13 +102,13 @@ public static class YoutubeService
         return output;
     }
 
-    public static async Task<long> GetSize(string url)
+    public static async Task<long?> GetSize(string url)
     {
         using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url))
         {
             HttpResponseMessage response
                 = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
-            return response.Content.Headers.ContentLength ?? 0;
+            return response.Content.Headers.ContentLength;
         }
     }
 }


### PR DESCRIPTION
1. Changed the YouTubeServices.GetSize method return type to a nullable long (long?)

2. Changed YouTubeServices.GetStreamAsync method. To set the fileSize to 0 if GetSize returns null.

This appears to have fixed my application crashing issues.