### PR TITLE
Address issue #43 (no album cover causes crash)

### DIFF
--- a/Spotisharp.Client/Services/SpotifyService.cs
+++ b/Spotisharp.Client/Services/SpotifyService.cs
@@ -60,7 +60,7 @@ public static class SpotifyService
                 DiscNumber = track.DiscNumber,
                 TrackNumber = track.TrackNumber,
                 Album = album.Name,
-                AlbumPicture = album.Images[0].Url,
+                AlbumPicture = album.Images.FirstOrDefault()?.Url ?? string.Empty,
                 Copyright = album.Copyrights.FirstOrDefault()?.Text ?? string.Empty,
                 Genres = artist.Genres.FirstOrDefault() ?? string.Empty,
                 Year = DateTime.TryParse(album.ReleaseDate, out var value) ? value.Year : int.Parse(album.ReleaseDate)

--- a/Spotisharp.Client/Services/SpotifyService.cs
+++ b/Spotisharp.Client/Services/SpotifyService.cs
@@ -108,7 +108,7 @@ public static class SpotifyService
                         DiscNumber = track.DiscNumber,
                         TrackNumber = track.TrackNumber,
                         Album = album.Name,
-                        AlbumPicture = album.Images[0].Url,
+                        AlbumPicture = album.Images.FirstOrDefault()?.Url ?? string.Empty,
                         Copyright = album.Copyrights.FirstOrDefault()?.Text ?? string.Empty,
                         Genres = artist.Genres.FirstOrDefault() ?? string.Empty,
                         Year = DateTime.TryParse(album.ReleaseDate, out var value) ? value.Year : int.Parse(album.ReleaseDate)
@@ -144,7 +144,7 @@ public static class SpotifyService
                 DiscNumber = track.DiscNumber,
                 TrackNumber = track.TrackNumber,
                 Album = album.Name ?? string.Empty,
-                AlbumPicture = album.Images[0].Url,
+                AlbumPicture = album.Images.FirstOrDefault()?.Url ?? string.Empty,
                 Copyright = album.Copyrights.FirstOrDefault()?.Text ?? string.Empty,
                 Genres = artist.Genres.FirstOrDefault() ?? string.Empty,
                 Year = DateTime.TryParse(album.ReleaseDate, out var value) ? value.Year : int.Parse(album.ReleaseDate)


### PR DESCRIPTION
Issue:
- some songs don't have an album cover. So when you try and download them they crash the entire program with an unsuccessful download

Solution:
- modified the code so that in the event the album image doesn't exist we return an empty string.

Test case:
- tested (https://open.spotify.com/track/3iINfVB6kucFrmMRWdLMWS?si=93a9f68c06ea40bd) which is known to cause the crash. Song downloaded with no problems