### PR TITLE
Update Program.cs to fix issue #43

### DIFF
--- a/Spotisharp.Client/Program.cs
+++ b/Spotisharp.Client/Program.cs
@@ -285,10 +285,13 @@ await Task.WhenAll(Enumerable.Range(0, workersCount).Select(async workerId =>
             file.Tag.Year = Convert.ToUInt32(trackInfo.Year);
             file.Tag.Comment = trackInfo.Url;
             file.Tag.Genres = new string[] { trackInfo.Genres };
-            file.Tag.Pictures = new TagLib.Picture[]
+            if (trackInfo.AlbumPicture != string.Empty)
             {
-                new TagLib.Picture(await albumPictureTask)
-            };
+                file.Tag.Pictures = new TagLib.Picture[]
+                {
+                    new TagLib.Picture(await albumPictureTask)
+                };
+            }
             file.Save();
         }
 


### PR DESCRIPTION
Fix secondary crash related to album cover

Issue:
- first fix addressed not being able to download files without album covers. But now the program crashes afterwards.

Root cause:
- in Program.cs, the TagLib.Picture line seems to not like empty strings

Solution:
- added a check to verify whether the string was empty before trying to save the AlbumPicture to file

Test case:
- tested song in issue #43. Song downloaded and no crash observed
- tested a song with an album cover. Song downloaded and no crash observed
- played both songs on MPC. No issues observed in track (song with album cover showed album cover)